### PR TITLE
ENH: future proof upload_time parsing (try to parse only the date as a fallback solution)

### DIFF
--- a/remove_old_wheels.py
+++ b/remove_old_wheels.py
@@ -1,4 +1,5 @@
 # Remove all but the latest N versions from wheels on Anaconda.org
+import re
 from datetime import datetime, timezone, timedelta
 
 import click
@@ -14,6 +15,10 @@ def _parse_upload_time(upload_time: str) -> datetime:
             return datetime.strptime(upload_time, fmt)
         except ValueError:
             continue
+    if (match := re.match(r"\d{4}-\d{2}-\d{2}", upload_time)) is not None:
+        # fallback solution: renounce everything but the date if it can be saved
+        return datetime.strftime(match.group())
+
     raise ValueError(
         f"Failed to parse upload time {upload_time!r} "
         "(didn't match any known format)"


### PR DESCRIPTION
Follow up to #9 as suggested by @ConorMacBride in https://github.com/OpenAstronomy/publish-wheels-anaconda/pull/9#issuecomment-1954931957